### PR TITLE
Fix/230 getServices func

### DIFF
--- a/src/provider/firebase.js
+++ b/src/provider/firebase.js
@@ -38,7 +38,7 @@ export const getServices = async () => {
       ...item.data(),
       id: item.id,
     }));
-    return { services };
+    return services;
   } catch (error) {
     console.warn('Error getting services, skip: ', error);
   }


### PR DESCRIPTION
Ошибка возникала в результате того, что функция getServices возвращала объект с массивом services. Поправлено на возврат массива.